### PR TITLE
Integration3 fix spoonacular details

### DIFF
--- a/src/components/spoonacular/recipe-info.js
+++ b/src/components/spoonacular/recipe-info.js
@@ -82,9 +82,12 @@ const RecipeInfo = ({recipe}) => {
             }
 
             {/* directions */}
-            <div className="row wd-border m-4">
-                <DirectionsList directions={recipe.analyzedInstructions[0]}/>
-            </div>
+            {
+                recipe.analyzedInstructions.length !== 0 &&
+                <div className="row wd-border m-4">
+                    <DirectionsList directions={recipe.analyzedInstructions[0]}/>
+                </div>
+            }
 
         </div>
     );

--- a/src/components/spoonacular/recipe-info.js
+++ b/src/components/spoonacular/recipe-info.js
@@ -74,9 +74,12 @@ const RecipeInfo = ({recipe}) => {
             </div>
 
             {/* ingredients */}
-            <div className="row wd-border m-4 mt-3">
-                <IngredientsList ingredients={recipe.extendedIngredients}/>
-            </div>
+            {
+                recipe.extendedIngredients.length !== 0 &&
+                <div className="row wd-border m-4 mt-3">
+                    <IngredientsList ingredients={recipe.extendedIngredients}/>
+                </div>
+            }
 
             {/* directions */}
             <div className="row wd-border m-4">

--- a/src/services/spoonacular-service.js
+++ b/src/services/spoonacular-service.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 
-const API_KEY = 'apiKey=540427b73f384d5b9d8afab31bf7e8ba';
+// const API_KEY = 'apiKey=540427b73f384d5b9d8afab31bf7e8ba';
+const API_KEY = 'apiKey=dc9b8ede1b034e4f8b6ef4a0402d4bce';
 const BASE_URL = 'https://api.spoonacular.com/recipes';
 
 export const findRecipesByIngredients = async (ingredients) => {


### PR DESCRIPTION
Added safeties to ingredients and directions lists for spoonacular recipes - some recipes do not have directions listed in their database. For example, the details for the "Homemade Garlic and Basil French Fries" recipe (first recipe that shows up after searching  with an ingredient of "potato") should now show up (previously could not render as noted by Yutong)